### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.3"
+          check-latest: true
+
+      - name: Run tests
+        run: |
+          go test -v -race .


### PR DESCRIPTION
## Summary
- add a `go test` workflow using actions/setup-go to run tests on pushes and PRs
- skip intentionally failing tests under `example`

## Testing
- `go test $(go list ./... | grep -v '/example')` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683fbffeea748327afb8f866ef63f7b0